### PR TITLE
Fix: Replace deprecated `pkg_resources` with `packaging`

### DIFF
--- a/pillow_jxl/JpegXLImagePlugin.py
+++ b/pillow_jxl/JpegXLImagePlugin.py
@@ -1,8 +1,8 @@
 from io import BytesIO
 
 import PIL
+from packaging.version import parse
 from PIL import Image, ImageFile
-from pkg_resources import parse_version
 
 from pillow_jxl import Decoder, Encoder
 
@@ -10,20 +10,20 @@ _VALID_JXL_MODES = {"RGB", "RGBA", "L", "LA"}
 
 
 def _accept(data):
-    return data[:2] == b'\xff\x0a' \
-        or data[:12] == b'\x00\x00\x00\x0c\x4a\x58\x4c\x20\x0d\x0a\x87\x0a' \
+    return (
+        data[:2] == b"\xff\x0a"
+        or data[:12] == b"\x00\x00\x00\x0c\x4a\x58\x4c\x20\x0d\x0a\x87\x0a"
         or data[4:7] == b"JXL"
+    )
 
 
 class JXLImageFile(ImageFile.ImageFile):
-
     format = "JXL"
     format_description = "Jpeg XL image"
     __loaded = -1
     __frame = 0
 
     def _open(self):
-
         self.fc = self.fp.read()
         self._decoder = Decoder()
 
@@ -31,7 +31,7 @@ class JXLImageFile(ImageFile.ImageFile):
         self._size = (self._jxlinfo.width, self._jxlinfo.height)
         self.rawmode = self._jxlinfo.mode
         # NOTE (Isotr0py): PIL 10.1.0 changed the mode to property, use _mode instead
-        if parse_version(PIL.__version__) >= parse_version("10.1.0"):
+        if parse(PIL.__version__) >= parse("10.1.0"):
             self._mode = self.rawmode
         else:
             self.mode = self.rawmode
@@ -39,22 +39,19 @@ class JXLImageFile(ImageFile.ImageFile):
         self.tile = []
 
     def seek(self, frame):
-
         self.load()
 
-        if self.__frame+1 != frame:
+        if self.__frame + 1 != frame:
             # I believe JPEG XL doesn't support seeking in animations
             raise NotImplementedError(
-                'Seeking more than one frame forward is currently not supported.'
+                "Seeking more than one frame forward is currently not supported."
             )
         self.__frame = frame
 
     def load(self):
-
         if self.__loaded != self.__frame:
-
             if self._data is None:
-                EOFError('no more frames')
+                EOFError("no more frames")
 
             self.__loaded = self.__frame
 
@@ -70,24 +67,23 @@ class JXLImageFile(ImageFile.ImageFile):
 
 
 def _save(im, fp, filename, save_all=False):
-
     if im.mode not in _VALID_JXL_MODES:
-        raise NotImplementedError('Only RGB, RGBA, L, LA are supported.')
+        raise NotImplementedError("Only RGB, RGBA, L, LA are supported.")
 
     info = im.encoderinfo.copy()
 
     # default quality is 1
-    lossless = info.get('lossless', False)
+    lossless = info.get("lossless", False)
     quality = 0 if lossless else 1
-    decoding_speed = info.get('decoding_speed', 0)
-    use_container = info.get('use_container', True)
+    decoding_speed = info.get("decoding_speed", 0)
+    use_container = info.get("use_container", True)
 
     enc = Encoder(
         mode=im.mode,
         lossless=lossless,
         quality=quality,
         decoding_speed=decoding_speed,
-        use_container=use_container
+        use_container=use_container,
     )
     data = enc(im.tobytes(), im.width, im.height)
     fp.write(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+    "packaging",
     "Pillow",
 ]
 


### PR DESCRIPTION
Fix:
- #13 

- Replace deprecated `pkg_resources` with `packaging`