### PR TITLE
🔧 (CI): Fix missing python3.10 in Mac CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,14 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-13
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        target: [x86_64, aarch64]
+        platform:
+          - runner: macos-latest
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,7 +134,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          architecture: ${{ matrix.target }}
       
       - name: Check dependencys
         run: |
@@ -149,14 +152,14 @@ jobs:
           DEP_BROTLI_LIB: /opt/homebrew/Cellar/brotli/1.1.0/lib
           DEP_HWY_LIB: /opt/homebrew/Cellar/highway/1.2.0/lib
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --features dynamic
           sccache: 'true'
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.target }}
+          name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
   sdist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         target: [x86_64, aarch64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
+          python-version: '3.10'
           architecture: ${{ matrix.target }}
       
       - name: Check dependencys
@@ -146,7 +147,7 @@ jobs:
           # from homebrew
           DEP_JXL_LIB: /opt/homebrew/Cellar/jpeg-xl/0.10.2/lib
           DEP_BROTLI_LIB: /opt/homebrew/Cellar/brotli/1.1.0/lib
-          DEP_HWY_LIB: /opt/homebrew/Cellar/highway/1.1.0/lib
+          DEP_HWY_LIB: /opt/homebrew/Cellar/highway/1.2.0/lib
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --features dynamic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           brew install jpeg-xl
           export DEP_JXL_LIB=/opt/homebrew/Cellar/jpeg-xl/0.10.2/lib
           export DEP_BROTLI_LIB=/opt/homebrew/Cellar/brotli/1.1.0/lib
-          export DEP_HWY_LIB=/opt/homebrew/Cellar/highway/1.1.0/lib
+          export DEP_HWY_LIB=/opt/homebrew/Cellar/highway/1.2.0/lib
           source venv/bin/activate
           pip install maturin
           maturin develop --features dynamic


### PR DESCRIPTION
Fix #47 