### PR TITLE
Add some metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ build-backend = "maturin"
 [project]
 name = "pillow-jxl-plugin"
 requires-python = ">=3.8"
+authors = [
+    { name = "Isotr0py" },
+]
+description = "Pillow plugin for JPEG-XL, using Rust for bindings."
+readme = "README.md"
+license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -14,6 +20,11 @@ dependencies = [
     "packaging",
     "Pillow",
 ]
+
+[project.urls]
+"Homepage" = "https://github.com/Isotr0py/pillow-jpegxl-plugin"
+"Bug Tracker" = "https://github.com/Isotr0py/pillow-jpegxl-plugin/issues"
+"Releases" = "https://github.com/Isotr0py/pillow-jpegxl-plugin/releases"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
The PyPI page didn't have a URL to the repository, so I added it to the pyproject.toml so it's reflected in the package metadata.