### PR TITLE
Multithreading: num_threads and no-GIL

### DIFF
--- a/pillow_jxl/JpegXLImagePlugin.py
+++ b/pillow_jxl/JpegXLImagePlugin.py
@@ -96,6 +96,7 @@ def _save(im, fp, filename, save_all=False):
     use_container = info.get("use_container", False)
     use_original_profile = info.get("use_original_profile", False)
     jpeg_encode = info.get("lossless_jpeg", True)
+    num_threads = info.get("num_threads", -1)
 
     enc = Encoder(
         mode=im.mode,
@@ -105,6 +106,7 @@ def _save(im, fp, filename, save_all=False):
         effort=effort,
         use_container=use_container,
         use_original_profile=use_original_profile,
+        num_threads=num_threads,
     )
     # FIXME (Isotr0py): im.filename maybe None if parse stream
     # TODO (Isotr0py): This part should be refactored in the near future

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -87,6 +87,16 @@ impl Decoder {
         _py: Python,
         data: &[u8],
     ) -> (bool, ImageInfo, Cow<'_, [u8]>, Cow<'_, [u8]>) {
+        _py.allow_threads(|| self.call_inner(data))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("Decoder"))
+    }
+}
+
+impl Decoder {
+    fn call_inner(&self, data: &[u8]) -> (bool, ImageInfo, Cow<'_, [u8]>, Cow<'_, [u8]>) {
         let parallel_runner = ThreadsRunner::new(
             None,
             if self.num_threads < 0 {
@@ -115,9 +125,5 @@ impl Decoder {
             Cow::Owned(img),
             Cow::Owned(icc_profile),
         )
-    }
-
-    fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("Decoder"))
     }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -67,7 +67,29 @@ impl Encoder {
     #[pyo3(signature = (data, width, height, jpeg_encode, exif=None, jumb=None, xmp=None))]
     fn __call__(
         &self,
-        _py: Python,
+        py: Python,
+        data: &[u8],
+        width: u32,
+        height: u32,
+        jpeg_encode: bool,
+        exif: Option<&[u8]>,
+        jumb: Option<&[u8]>,
+        xmp: Option<&[u8]>,
+    ) -> Cow<'_, [u8]> {
+        py.allow_threads(|| self.call_inner(data, width, height, jpeg_encode, exif, jumb, xmp))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "Encoder(has_alpha={}, lossless={}, quality={}, decoding_speed={}, effort={}, num_threads={})",
+            self.has_alpha, self.lossless, self.quality, self.decoding_speed, self.effort, self.num_threads
+        ))
+    }
+}
+
+impl Encoder {
+    fn call_inner(
+        &self,
         data: &[u8],
         width: u32,
         height: u32,
@@ -134,12 +156,5 @@ impl Encoder {
             }
         };
         Cow::Owned(buffer.data)
-    }
-
-    fn __repr__(&self) -> PyResult<String> {
-        Ok(format!(
-            "Encoder(has_alpha={}, lossless={}, quality={}, decoding_speed={}, effort={}, num_threads={})",
-            self.has_alpha, self.lossless, self.quality, self.decoding_speed, self.effort, self.num_threads
-        ))
     }
 }


### PR DESCRIPTION
Adds support for the `num_threads` parameter and GIL releasing in the Encoder/Decoder.

For batch conversions with ample memory, transcoding multiple files concurrently is often more efficient, but requires reducing or disabling libjxl's parallelism. Releasing the GIL enables concurrent jxl operations in a single python process.

Encoder parallelism can be configured via `Image.save(num_threads=<n>)`. The decoder supports this too, though Pillow lacks a direct way to pass arguments. A settable module constant might be an option—open to feedback on this.

Behavior mirrors `cjxl`'s `--num_threads` parameter:
> -1: machine default, 0: single-threaded.
