### PR TITLE
don't store empty exif profiles (forcing the use of JXL container)

### DIFF
--- a/pillow_jxl/JpegXLImagePlugin.py
+++ b/pillow_jxl/JpegXLImagePlugin.py
@@ -122,7 +122,10 @@ def _save(im, fp, filename, save_all=False):
         with open(im.filename, "rb") as f:
             data = enc(f.read(), im.width, im.height, jpeg_encode=True)
     else:
-        exif = info.get("exif", im.getexif().tobytes())
+        exif = info.get("exif")
+        if exif is None:
+            exif = im.getexif()
+            exif = exif.tobytes() if exif else None
         if exif and exif.startswith(b"Exif\x00\x00"):
             exif = exif[6:]
         metadata = {


### PR DESCRIPTION
Image.getexif().tobytes() always returns a non empty string. The truth value of the Exif object should be used instead.