### PR TITLE
🔧 (CI): Enable benchmark CI on linux and windows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install libjxl
         uses: msys2/setup-msys2@v2
-        if: ${{ matrix.features == 'dynamic' }}
         with:
           update: true
           install: >-


### PR DESCRIPTION
- Enable benchmark CI on linux and windows