### PR TITLE
(Plugin): Implement float 16 decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version="0.26.0", features = ["extension-module", "generate-import-lib"] }
 jpegxl-rs = { version="0.11.2", default-features = false }
+half = "2.7.1"
 
 [features]
 # Enables parallel processing support by enabling the "rayon" feature of jpeg-decoder.

--- a/pillow_jxl/JpegXLImagePlugin.py
+++ b/pillow_jxl/JpegXLImagePlugin.py
@@ -53,6 +53,9 @@ class JXLImageFile(ImageFile.ImageFile):
         self._decoder = Decoder(num_threads=DECODE_THREADS)
 
         self.jpeg, self._jxlinfo, self._data, icc_profile = self._decoder(self.fc)
+        if self._jxlinfo.mode == "F;16":
+            warnings.warn("Pillow doesn't support 16 bit floats, upcasting to 32 bits.")
+            self._jxlinfo.mode = "F"
         # FIXME (Isotr0py): Maybe slow down jpeg reconstruction
         if self.jpeg:
             with Image.open(BytesIO(self._data)) as im:


### PR DESCRIPTION
This adds support for f16 JPEG XLs by upcasting to float32 as Pillow doesn't support it natively.
These types of images are frequent in scientific computing and thus should be supported.

Currently, a warning is displayed when reading a 16 bit floating point JXL to notify the user of the upcast.
```python
>>> from PIL import Image
>>> import pillow_jxl
>>> image = Image.open("../jxl-depth/depth_f16.jxl")
pillow-jpegxl-plugin/pillow_jxl/JpegXLImagePlugin.py:57: UserWarning: Pillow doesn't support 16 bit floats, upcasting to 32 bits.
  warnings.warn("Pillow doesn't support 16 bit floats, upcasting to 32 bits.")
```