### PR TITLE
Added encode effort=10 (present in jpegxl-rs).

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -185,6 +185,7 @@ impl Encoder {
             7 => EncoderSpeed::Squirrel,
             8 => EncoderSpeed::Kitten,
             9 => EncoderSpeed::Tortoise,
+            10 => EncoderSpeed::Glacier,
             _ => return Err(PyValueError::new_err("Invalid effort")),
         };
 


### PR DESCRIPTION
The rust lib (jpegxl-rs) includes an additional encode effort level (10 Glacier). Updating this python plugin to enable it.